### PR TITLE
Revert "chore(deps): bump ink-spinner from 4.0.3 to 5.0.0 in /packages/concourse-ts"

### DIFF
--- a/packages/concourse-ts/package.json
+++ b/packages/concourse-ts/package.json
@@ -34,7 +34,7 @@
     "@swc/helpers": "~0.4.11",
     "fast-glob": "^3.2.12",
     "ink": "^3.2.0",
-    "ink-spinner": "^5.0.0",
+    "ink-spinner": "^4.0.3",
     "ink-table": "^3.0.0",
     "ink-use-stdout-dimensions": "^1.0.5",
     "mkdirp": "^2.1.3",


### PR DESCRIPTION
Reverts DecentM/concourse-ts#63